### PR TITLE
Handle 'null' nicknames

### DIFF
--- a/officehours.js
+++ b/officehours.js
@@ -12,7 +12,11 @@ const { OFFICE_HOURS, TA_CHANNEL } = process.env;
 const onlineTas = { };
 
 function getNickname(message) {
-  return message.guild.member(message.author).nickname;
+  const member = message.guild.member(message.author);
+  if (member.nickname !== null) {
+    return member.nickname;
+  }
+  return member.user.username;
 }
 
 function isOnline(member) {


### PR DESCRIPTION
# Description

When TAs ready a user in the queue, and the bot tells the user the TA is ready for them, the bot would default to using the TAs nickname, but if they don't have a nickname it would be null. This patch tries the nickname, and if they don't have one falls back to their username.

Fixes #29 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] 🐞 Bug fix
<!-- Non-breaking change which fixes an issue -->
  
# How Has This Been Tested?

<!-- Unless this is a documentation change, please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

- [x] Tested individually.
<!-- Performed tests individually on a development deployment. -->

# Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings.
- [x] My changes do not break any features.
<!-- This not the same as a **Breaking Change**. You have tested that all other features are not affected by this change. -->